### PR TITLE
Close Events Channel

### DIFF
--- a/search.go
+++ b/search.go
@@ -105,7 +105,7 @@ func (conn SplunkConnection) SearchStream(searchString string, params ...map[str
 				events <- &row
 			}
 		}
-		events <- nil //Signal EOF
+		defer close(events) //Signal EOF
 	}()
 
 	return events,err


### PR DESCRIPTION
### Gracefully closing channel

 - There are situations where an unclosed channel could end up in leaving the reader hanging for more data, even if a nil value has been sent.
 - Closing the channel is the right way to tell the reader that there's no more data and that it can move forward.